### PR TITLE
Add ability to choose if exit signs are placed.

### DIFF
--- a/src/modules/miscellaneous.lua
+++ b/src/modules/miscellaneous.lua
@@ -102,7 +102,14 @@ OB_MODULES["misc"] =
 
     { name="doors",       label=_("Doors"),          choices=STYLE_CHOICES }
     { name="keys",        label=_("Keyed Doors"),    choices=STYLE_CHOICES }
-    { name="switches",    label=_("Switched Doors"), choices=STYLE_CHOICES }
+    { name="switches",    label=_("Switched Doors"), choices=STYLE_CHOICES, gap=1 }
+
+    {
+      name="exit_signs"
+      label=_("Exit Signs")
+      choices=MISC_STUFF.YES_NO
+      tooltip=_("Places exit signs by exiting room")
+    }
 
 ---- PLANNED (UNFINISHED) STUFF ----
 


### PR DESCRIPTION
Exit signs were added by default to Oblige in 7.666.  While they are generally very helpful, they can make the exit too obvious when keyed doors are disabled.  By not allowing exit signs, the player needs to discover where the exit is.