### PR TITLE
Makefile fix for mkdir

### DIFF
--- a/scripts/makefile
+++ b/scripts/makefile
@@ -3,7 +3,7 @@ all: obaddon-build
 
 # Do the actual build
 obaddon-build:
-	mkdir build
+	mkdir -p build
 	cd ../src; zip -vr ../scripts/build/obaddon.pk3 *
 
 # Clean


### PR DESCRIPTION
On Linux, mkdir fails if the directory already exists. The -p switch's main purpose is to create parent directories automatically when attempting to make a nested directory structure, but the other thing it does is that it causes mkdir to exit successfully if it doesn't have to do anything.