### PR TITLE
Update materials.lua

### DIFF
--- a/src/games/doom/materials.lua
+++ b/src/games/doom/materials.lua
@@ -642,7 +642,7 @@ DOOM.MATERIALS =
   MIDSPACE = { t="MIDSPACE", rail_h=128 }
 
   -- scaled MIDVINE2 from FreeDoom
-  MIDVINE2 = { t="SP_DUDE8", rail_h=128 }
+  MIDVINE2 = { t="MIDVINE2", rail_h=128 }
 
 
   -- liquid stuff (keep them recognisable)


### PR DESCRIPTION
Caves entrance's and/or holes in the wall aren't using MIDVINE2, and instead use SP_DUDE8, and it's confusing since in the maps generated by Obaddon it doesn't looks like a hole in the wall with vines, but instead a brick wall with a corpse.